### PR TITLE
feat: add recreate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,28 @@ cy.dataSession({
 })
 ```
 
+### recreate
+
+Using the options object you can pass another function to be called after the `validate` yields true. This function let's you to perform Cypress commands with the validated value to "finish" the recreation. For example, you could visit the page after setting the cookie from the data session to end on the page, just like the `setup` does.
+
+```js
+cy.dataSession({
+  name: 'logged in',
+  setup: () => {
+    // create user, visit the page, log in
+    // let's say we are on the page '/home
+    // save the cookie in the data session
+    cy.getCookie('connect.sid')
+  },
+  // assume the cookie is valid
+  validate: (c) => true,
+  recreate (cookie) => {
+    cy.setCookie(cookie)
+    cy.visit('/home')
+  }
+})
+```
+
 ### shareAcrossSpecs
 
 By default, the data session value is saved inside `Cypress.env` object. This object is reset whenever the spec gets reloaded (think Cmd+R press or the full browser reload). The object is gone when the `cypress run` finishes with a spec and opens another one. If you want the data value to persist across the browser reloads, or be shared across specs, use the `shareAcrossSpecs: true` option.

--- a/cypress/integration/recreate.js
+++ b/cypress/integration/recreate.js
@@ -1,0 +1,45 @@
+// @ts-check
+/// <reference path="../../src/index.d.ts" />
+
+import '../../src'
+
+describe('dataSession', () => {
+  const name = 'recreate-me'
+
+  beforeEach(() => {
+    Cypress.clearDataSession(name)
+  })
+
+  it('calls recreate', () => {
+    const setup = cy.stub().as('setup').returns(42)
+    const validate = cy.stub().as('validate').returns(true)
+    const recreate = cy.stub().as('recreate')
+
+    cy.dataSession({
+      name,
+      setup,
+      validate,
+      recreate,
+    }).then((value) => {
+      expect(value).to.equal(42)
+      cy.get('@setup').should('have.been.calledOnce').invoke('resetHistory')
+      cy.get('@recreate').should('not.have.been.called')
+    })
+
+    // on next call, the setup should not be called, but validate should be
+    // and then it calls recreate function
+    cy.dataSession({
+      name,
+      setup,
+      validate,
+      recreate,
+    }).then((value) => {
+      expect(value).to.equal(42)
+      cy.get('@setup').should('not.have.been.called')
+      cy.get('@validate')
+        .should('have.been.calledOnceWith', 42)
+        .invoke('resetHistory')
+      cy.get('@recreate').should('have.been.calledOnceWith', 42)
+    })
+  })
+})

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,7 @@ declare namespace Cypress {
     setup: Function
     validate: Validate
     onInvalidated?: Function
+    recreate?: Validate
     shareAcrossSpecs?: boolean
   }
 


### PR DESCRIPTION
Using the options object you can pass another function to be called after the `validate` yields true. This function let's you to perform Cypress commands with the validated value to "finish" the recreation. For example, you could visit the page after setting the cookie from the data session to end on the page, just like the `setup` does.

```js
cy.dataSession({
  name: 'logged in',
  setup: () => {
    // create user, visit the page, log in
    // let's say we are on the page '/home
    // save the cookie in the data session
    cy.getCookie('connect.sid')
  },
  // assume the cookie is valid
  validate: (c) => true,
  recreate (cookie) => {
    cy.setCookie(cookie)
    cy.visit('/home')
  }
})
```