### PR TITLE
feat: implement dependsOn

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ dependsOn: ['first', 'second', 'third']
 A few global utility methods are added to the `Cypress` object for accessing the data sessions. These methods are mostly utilities used internally.
 
 - `Cypress.getDataSession(name)`
+- `Cypress.getDataSessionDetails(name)`
 - `Cypress.clearDataSession(name)`
 - `Cypress.dataSessions(enable)`
 - `Cypress.setDataSession(name, value)`

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A few global utility methods are added to the `Cypress` object for accessing the
 - `Cypress.getDataSession(name)`
 - `Cypress.clearDataSession(name)`
 - `Cypress.dataSessions(enable)`
+- `Cypress.setDataSession(name, value)`
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,48 @@ cy.dataSession({
 })
 ```
 
+### dependsOn
+
+A data session can depend on another data session or even multiple data sessions. For example, the data session "logged in user" can depend on the "created user" data session. If the "parent" session changes, we need to recompute all sessions that depend on it.
+
+```js
+cy.dataSession({
+  name: 'created user',
+  setup () {
+    // create a user
+  }
+})
+
+cy.dataSession({
+  name: 'logged in user',
+  dependsOn: 'created user',
+  setup () {
+    // take the user object from
+    // the data session "created user"
+    // and log in
+  }
+})
+```
+
+If the "created user" gets invalidated and recomputed (its `setup` method runs again), then the data session "logged in user" is invalidated automatically.
+
+To list dependencies on multiple data sessions, pass an array of names
+
+```js
+dependsOn: ['first', 'second', 'third']
+```
+
 ## Examples
 
 - [bahmutov/chat.io](https://github.com/bahmutov/chat.io)
+
+## Global methods
+
+A few global utility methods are added to the `Cypress` object for accessing the data sessions. These methods are mostly utilities used internally.
+
+- `Cypress.getDataSession(name)`
+- `Cypress.clearDataSession(name)`
+- `Cypress.dataSessions(enable)`
 
 ## Debugging
 

--- a/cypress/integration/dependent.js
+++ b/cypress/integration/dependent.js
@@ -28,7 +28,7 @@ describe('Dependent data session', () => {
       dependsOn: ['parent'],
     }
     cy.dataSession(childOptions).then(() => {
-      const childDataSession = Cypress.getDataSession('child')
+      const childDataSession = Cypress.getDataSessionDetails('child')
       expect(childDataSession)
         .to.have.property('dependsOnTimestamps')
         .to.be.an('Array')
@@ -39,7 +39,7 @@ describe('Dependent data session', () => {
         .invoke('resetHistory')
         .then(() => {
           // confirm the internals
-          const parentDataSession = Cypress.getDataSession('parent')
+          const parentDataSession = Cypress.getDataSessionDetails('parent')
           expect(parentDataSession).to.have.keys(
             'data',
             'timestamp',
@@ -67,7 +67,8 @@ describe('Dependent data session', () => {
               cy.get('@parentSetup')
                 .should('be.calledOnce')
                 .then(() => {
-                  const newParentDataSession = Cypress.getDataSession('parent')
+                  const newParentDataSession =
+                    Cypress.getDataSessionDetails('parent')
                   expect(newParentDataSession).to.have.keys(
                     'data',
                     'timestamp',

--- a/cypress/integration/global-methods.js
+++ b/cypress/integration/global-methods.js
@@ -1,0 +1,36 @@
+// @ts-check
+/// <reference path="../../src/index.d.ts" />
+
+import '../../src'
+
+describe('global session methods', () => {
+  beforeEach(() => {
+    cy.dataSession({
+      name: 'C',
+      setup: () => 'c',
+      validate: (x) => x === 'd',
+    })
+  })
+
+  it('exist on Cypress object', () => {
+    expect(Cypress).to.include.keys(
+      'getDataSessionDetails',
+      'getDataSession',
+      'dataSessions',
+      'setDataSession',
+      'clearDataSession',
+    )
+  })
+
+  it('has getDataSessionDetails', () => {
+    const ds = Cypress.getDataSessionDetails('C')
+    expect(ds).to.deep.include({
+      data: 'c',
+    })
+  })
+
+  it('has getDataSession', () => {
+    const ds = Cypress.getDataSession('C')
+    expect(ds).to.equal('c')
+  })
+})

--- a/cypress/integration/invalidate.js
+++ b/cypress/integration/invalidate.js
@@ -6,7 +6,7 @@ import '../../src'
 describe('Data C', () => {
   it('exists under an alias', function () {
     // force invalidation by putting some random data
-    Cypress.env('dataSession:C', 42)
+    Cypress.setDataSession('C', 42)
 
     cy.dataSession(
       'C',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,6 +10,7 @@ declare namespace Cypress {
     onInvalidated?: Function
     recreate?: Function
     shareAcrossSpecs?: boolean
+    dependsOn?: string | string[]
   }
 
   type Validate = ((x: any) => Chainable<boolean>) | ((x: any) => boolean)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,6 +40,7 @@ declare namespace Cypress {
   // utility global methods added to Cypress global object
   interface Cypress {
     getDataSession: (name: string) => any
+    getDataSessionDetails: (name: string) => any
     setDataSession: (name: string, data: any) => void
     clearDataSession: (name: string) => void
     dataSessions: (enable: boolean) => void

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,6 +40,7 @@ declare namespace Cypress {
   // utility global methods added to Cypress global object
   interface Cypress {
     getDataSession: (name: string) => any
+    setDataSession: (name: string, data: any) => void
     clearDataSession: (name: string) => void
     dataSessions: (enable: boolean) => void
   }

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ Cypress.Commands.add('dataSession', (name, setup, validate, onInvalidated) => {
 
   function getDependsOnTimestamps() {
     return dependsOn.map((dep) => {
-      const ds = Cypress.getDataSession(dep)
+      const ds = Cypress.getDataSessionDetails(dep)
       if (!ds) {
         throw new Error(
           `Cannot find data session "${dep}" session "${name}" depends on`,
@@ -218,6 +218,15 @@ Cypress.dataSessions = (enable) => {
 }
 
 Cypress.getDataSession = (name) => {
+  const entry = Cypress.getDataSessionDetails(name)
+  if (!entry) {
+    return undefined
+  }
+
+  return entry.data
+}
+
+Cypress.getDataSessionDetails = (name) => {
   const dataKey = formDataKey(name)
   return Cypress.env(dataKey)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -221,3 +221,18 @@ Cypress.getDataSession = (name) => {
   const dataKey = formDataKey(name)
   return Cypress.env(dataKey)
 }
+
+Cypress.setDataSession = (name, data) => {
+  if (Cypress._.isNil(data)) {
+    throw new Error(
+      `Cannot set data session "${name}" to undefined or undefined`,
+    )
+  }
+
+  const dataKey = formDataKey(name)
+  const timestamp = +new Date()
+  const dependsOnTimestamps = []
+
+  const sessionData = { data, timestamp, dependsOnTimestamps }
+  Cypress.env(dataKey, sessionData)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,18 @@ Cypress.Commands.add('dataSession', (name, setup, validate, onInvalidated) => {
 
   const dataKey = formDataKey(name)
 
+  function getDependsOnTimestamps() {
+    return dependsOn.map((dep) => {
+      const ds = Cypress.getDataSession(dep)
+      if (!ds) {
+        throw new Error(
+          `Cannot find data session "${dep}" session "${name}" depends on`,
+        )
+      }
+      return ds.timestamp
+    })
+  }
+
   const setupAndSaveData = () => {
     if (preSetup) {
       cy.then(preSetup)
@@ -73,7 +85,11 @@ Cypress.Commands.add('dataSession', (name, setup, validate, onInvalidated) => {
       if (!pluginDisabled) {
         // only save the data if the plugin is enabled
         // save the data for this session
-        Cypress.env(dataKey, data)
+        const timestamp = +new Date()
+        const dependsOnTimestamps = getDependsOnTimestamps()
+
+        const sessionData = { data, timestamp, dependsOnTimestamps }
+        Cypress.env(dataKey, sessionData)
 
         // TODO: implement dependsOn
 
@@ -93,9 +109,11 @@ Cypress.Commands.add('dataSession', (name, setup, validate, onInvalidated) => {
 
   cy.log(`dataSession **${name}**`)
 
-  cy.wrap(Cypress.env(dataKey), { log: false })
+  const entry = Cypress.env(dataKey)
+  cy.wrap(entry ? entry.data : undefined, { log: false })
     .then((value) => {
       if (shareAcrossSpecs) {
+        // TODO: save and load save data as Cypress.env does
         return cy.task('dataSession:load', dataKey)
       }
     })
@@ -117,15 +135,45 @@ Cypress.Commands.add('dataSession', (name, setup, validate, onInvalidated) => {
         )
       }
 
+      /**
+       * Looks up the timestamps from the data sessions
+       * this session depends on. If any of the timestamps
+       * are different, that means a "parent" data session
+       * was recomputed and we must recompute our data.
+       */
+      function parentsRecomputed() {
+        if (!entry) {
+          return false
+        }
+        if (!entry.dependsOnTimestamps) {
+          throw new Error(
+            `Missing depends on timestamps for data session "${name}"`,
+          )
+        }
+        const currentTimestamps = getDependsOnTimestamps()
+        const same = Cypress._.isEqual(
+          entry.dependsOnTimestamps,
+          currentTimestamps,
+        )
+        return same
+      }
+
       cy.then(() => validate(value)).then((valid) => {
         if (valid) {
-          cy.log(`data **${name}** is still valid`)
-          if (Cypress._.isFunction(recreate)) {
-            cy.log(`recreating **${name}**`)
-            return cy.then(() => recreate(value)).then(returnValue)
-          }
+          const parentSessionsAreTheSame = parentsRecomputed()
+          if (!parentSessionsAreTheSame) {
+            cy.log(
+              `recomputing **${name}** because a parent session has been recomputed`,
+            )
+          } else {
+            cy.log(`data **${name}** is still valid`)
+            if (Cypress._.isFunction(recreate)) {
+              cy.log(`recreating **${name}**`)
+              return cy.then(() => recreate(value)).then(returnValue)
+            }
 
-          return returnValue()
+            return returnValue()
+          }
         }
 
         cy.then(() => {


### PR DESCRIPTION
- closes #9 

A data session can depend on another data session or even multiple data sessions. For example, the data session "logged in user" can depend on the "created user" data session. If the "parent" session changes, we need to recompute all sessions that depend on it.

```js
cy.dataSession({
  name: 'created user',
  setup () {
    // create a user
  }
})

cy.dataSession({
  name: 'logged in user',
  dependsOn: 'created user',
  setup () {
    // take the user object from
    // the data session "created user"
    // and log in
  }
})
```

If the "created user" gets invalidated and recomputed (its `setup` method runs again), then the data session "logged in user" is invalidated automatically.

To list dependencies on multiple data sessions, pass an array of names

```js
dependsOn: ['first', 'second', 'third']
```