### PR TITLE
feat: invalidate session if setup function changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ See [src/index.d.ts](./src/index.d.ts)
 
 ## Use
 
+You can call `cy.dataSession` with simple 3 arguments or with an options object that allows you to pass more options.
+
+### three arguments
+
+```js
+cy.dataSession(sessionName, setupFunction, validateValueFunction)
+```
+
 This example comes from [cypress/integration/spec.js](./cypress/integration/spec.js)
 
 ```js
@@ -76,6 +84,8 @@ it('exists under an alias', function () {
   expect(this.A).to.equal('a')
 })
 ```
+
+Note: if the `setup` function's text changes, the session is recomputed.
 
 ### validate
 

--- a/cypress/integration/dependent.js
+++ b/cypress/integration/dependent.js
@@ -43,6 +43,7 @@ describe('Dependent data session', () => {
             'data',
             'timestamp',
             'dependsOnTimestamps',
+            'setupHash',
           )
           expect(parentDataSession).to.have.property('data', 1)
           expect(parentDataSession)
@@ -72,6 +73,7 @@ describe('Dependent data session', () => {
                     'data',
                     'timestamp',
                     'dependsOnTimestamps',
+                    'setupHash',
                   )
                   expect(newParentDataSession).to.have.property('data', 1)
                   const newParentTimestamp = newParentDataSession.timestamp
@@ -147,6 +149,7 @@ describe('Dependent data session across specs', () => {
               'data',
               'timestamp',
               'dependsOnTimestamps',
+              'setupHash',
             )
             expect(parentDataSession).to.have.property('data', 1)
             expect(parentDataSession)
@@ -176,6 +179,7 @@ describe('Dependent data session across specs', () => {
                       'data',
                       'timestamp',
                       'dependsOnTimestamps',
+                      'setupHash',
                     )
                     expect(newParentDataSession).to.have.property('data', 1)
                     const newParentTimestamp = newParentDataSession.timestamp

--- a/cypress/integration/global-methods.js
+++ b/cypress/integration/global-methods.js
@@ -41,7 +41,7 @@ describe('global session methods', () => {
     })
   })
 
-  it.only('clears the data sessions', () => {
+  it('clears the data sessions', () => {
     const sessions = Cypress.dataSessions()
     expect(sessions).to.have.length.greaterThan(0)
     Cypress.clearDataSessions()

--- a/cypress/integration/setup-changes.js
+++ b/cypress/integration/setup-changes.js
@@ -1,0 +1,50 @@
+// @ts-check
+
+import '../../src'
+
+describe('setup function changes', () => {
+  const name = 'setup-changes-example'
+
+  beforeEach(() => {
+    // force starting fresh
+    Cypress.clearDataSession(name)
+  })
+
+  it('invalidates the session, ', () => {
+    const stub1 = cy.stub().as('setup').returns(42)
+    const setup = () => stub1()
+
+    const stub2 = cy.stub().as('setup2').returns(101)
+    const setup2 = () => stub2()
+
+    cy.dataSession(name, setup, true)
+      .then(function (value) {
+        expect(value, 'yielded').to.equal(42)
+        expect(this[name], 'aliased').to.equal(42)
+        expect(this.setup).to.be.calledOnce
+        expect(this.setup2).to.not.be.called
+        this.setup.resetHistory()
+      })
+      .then(() => {
+        // if we use the same setup function, then the session is not invalidated
+        cy.log('**same setup function**')
+        cy.dataSession(name, setup, true)
+          .then(function (value) {
+            expect(value, 'yielded').to.equal(42)
+            expect(this[name], 'aliased').to.equal(42)
+            expect(this.setup).to.not.be.called
+            expect(this.setup2).to.not.be.called
+          })
+          .then(() => {
+            // if we changing the spec function
+            cy.log('**changed setup function**')
+            cy.dataSession(name, setup2, true).then(function (value) {
+              expect(value, 'yielded').to.equal(101)
+              expect(this[name], 'aliased').to.equal(101)
+              expect(this.setup).to.not.be.called
+              expect(this.setup2).to.be.calledOnce
+            })
+          })
+      })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -5233,6 +5233,11 @@
         }
       }
     },
+    "simple-sha256": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/simple-sha256/-/simple-sha256-1.1.0.tgz",
+      "integrity": "sha512-jMdj+5MR1dRiFbrQ8idmkPv+HCoJEmJVBBwc0vQQz4Gtg3PEkjdpVxUM4BSwK898zhNP/ub3vcP9edw47EHuLQ=="
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "debug": "^4.3.2"
+    "debug": "^4.3.2",
+    "simple-sha256": "^1.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ Cypress.Commands.add('dataSession', (name, setup, validate, onInvalidated) => {
       }
 
       return sha256(setupSource).then((setupHash) => {
-        if (entry.setupHash && entry.setupHash !== setupHash) {
+        if (entry && entry.setupHash && entry.setupHash !== setupHash) {
           // the setup function has changed,
           // we need to re-run the setup commands
           cy.log(`setup function changed for session **${name}**`)

--- a/src/sha.js
+++ b/src/sha.js
@@ -1,0 +1,39 @@
+// from simple-sha256
+// but with the fix https://github.com/feross/simple-sha256/pull/2
+module.exports = sha256
+
+const crypto = globalThis.crypto || globalThis.msCrypto
+const subtle = crypto.subtle || crypto.webkitSubtle
+
+function sha256sync(buf) {
+  throw new Error('No support for sha256.sync() in the browser, use sha256()')
+}
+
+async function sha256(buf) {
+  if (typeof buf === 'string') buf = strToBuf(buf)
+
+  // Browsers throw if they lack support for an algorithm.
+  // Promise will be rejected on non-secure origins. (http://goo.gl/lq4gCo)
+  const hash = await subtle.digest({ name: 'sha-256' }, buf)
+  return hex(new Uint8Array(hash))
+}
+
+function strToBuf(str) {
+  const len = str.length
+  const buf = new Uint8Array(len)
+  for (let i = 0; i < len; i++) {
+    buf[i] = str.charCodeAt(i)
+  }
+  return buf
+}
+
+function hex(buf) {
+  const len = buf.length
+  const chars = []
+  for (let i = 0; i < len; i++) {
+    const byte = buf[i]
+    chars.push((byte >>> 4).toString(16))
+    chars.push((byte & 0x0f).toString(16))
+  }
+  return chars.join('')
+}


### PR DESCRIPTION
- closes #19 
If the `setup` function text changes (using has of `setup.toString()`), recomputes the data session value