### PR TITLE
Add example for issue 36

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,3 @@
 {
-  "fixturesFolder": false,
-  "supportFile": false
+  "fixturesFolder": false
 }

--- a/cypress/integration/deep-save/cache-a.js
+++ b/cypress/integration/deep-save/cache-a.js
@@ -1,0 +1,11 @@
+// @ts-check
+import '../../../src'
+
+describe('setting up shared cache', () => {
+  it('sets up a shared cache', () => {
+    const setupSpy = cy.spy()
+    cy.cacheAcrossSpecs(setupSpy).then(() => {
+      expect(setupSpy).to.be.calledOnce
+    })
+  })
+})

--- a/cypress/integration/deep-save/cache-b.js
+++ b/cypress/integration/deep-save/cache-b.js
@@ -1,0 +1,11 @@
+// @ts-check
+import '../../../src'
+
+describe('using pre-saved cache', () => {
+  it('uses a shared cache', () => {
+    const setupSpy = cy.spy()
+    cy.cacheAcrossSpecs(setupSpy).then(() => {
+      expect(setupSpy).not.to.be.called
+    })
+  })
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,12 @@
+Cypress.Commands.add('cacheAcrossSpecs', (cb) => {
+  cy.dataSession({
+    name: 'cache-across-specs',
+    setup: () => {
+      cy.log('setting up')
+      cb()
+      cy.then(() => 'done')
+    },
+    validate: true,
+    shareAcrossSpecs: true,
+  })
+})

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "test": "cypress run",
+    "test:open": "cypress open",
     "semantic-release": "semantic-release",
     "lint": "tsc --pretty --noEmit --allowJS cypress/**/*.js"
   },


### PR DESCRIPTION
Ref #36

To reproduce, run 

```
npm run test:open
```

Then, run `deep-save/cache-a` first.  This will run the `setup` function and save some fake data in the cache.

Next, run `deep-save/cache-b`.  It _should_ use the cached value and not run the `setup` again, but it does.  A refresh of the page will fail, but a hard refresh succeeds.  I don't quite understand why.