### PR TITLE
feat: adde fetching the data session value without overwriting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,18 @@ cy.dataSession({
 
 The above example will find the test user (by calling the `cy.task`) the very first time the command runs, since there is nothing in the data session yet. Then it validates the ID. If there is no ID, it runs the `setup` function to create the test user. If there is a test user, and it returned the ID from the `init` method, then it is cached (as if the `setup` method created it), and the test continues.
 
+### fetch the current data session value
+
+You can simply request the current data session, if any
+
+```js
+cy.dataSession('sessionName').then(value => {
+  ...
+})
+```
+
+If the data session is not found in memory, it tries to fetch it from the plugins space (maybe it is shared across specs). If still not found, it throws an error.
+
 ## Flow
 
 Consider the `cy.dataSession(options)` where the `options` object might have the following method callbacks: `validate`, `init`, `setup`, `preSetup`, `recreate`, and `onInvalidated`. Your case might provide just some of these callback functions, but let's say you have provided all of them. Here is how they will be called.

--- a/cypress/e2e/get-session.cy.js
+++ b/cypress/e2e/get-session.cy.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+import '../../src'
+
+describe('get data', () => {
+  it('creates data session', () => {
+    const projectName = `my random project ${Cypress._.random(1e4)}`
+    // this test prints a new random name,
+    // but the data session is the same
+    // after the first run
+    cy.log(projectName)
+    cy.dataSession({
+      name: 'project name',
+      setup() {
+        return projectName
+      },
+      shareAcrossSpecs: true,
+    }).then(cy.log)
+  })
+
+  it('get the data session', () => {
+    cy.dataSession('project name').then(cy.log)
+  })
+})

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -83,6 +83,11 @@ declare namespace Cypress {
      * @see https://github.com/bahmutov/cypress-data-session
      */
     dataSession(options: DataSessionOptions): Chainable<any>
+
+    /**
+     * Fetches the current value stored for the given data session.
+     */
+    dataSession(name: string): Chainable<any>
   }
 
   // utility global methods added to Cypress global object

--- a/src/index.js
+++ b/src/index.js
@@ -31,266 +31,289 @@ function extractKey(key) {
   return key.replace('dataSession:', '')
 }
 
+function getDataSession(name) {
+  const dataKey = formDataKey(name)
+  const entry = getPluginConfigValue(dataKey)
+  if (entry) {
+    return entry.data
+  }
+  return cy.task('dataSession:load', dataKey).then((loaded) => {
+    if (loaded) {
+      return loaded.data
+    }
+
+    throw new Error(`Could not find data session with name "${name}"`)
+  })
+}
+
 // The predicate "validate" function checks the cached data
 // against the current data to determine if we need to re-run
 // the setup commands.
-Cypress.Commands.add('dataSession', (name, setup, validate, onInvalidated) => {
-  let shareAcrossSpecs = false
-  let init = Cypress._.noop
-  let preSetup
-  let recreate
-  let dependsOn
-
-  // check if we are using options / separate arguments
-  if (typeof name === 'object') {
-    const options = name
-    name = options.name
-    if ('init' in options) {
-      init = options.init
+Cypress.Commands.add(
+  'dataSession',
+  function (name, setup, validate, onInvalidated) {
+    if (arguments.length === 1 && Cypress._.isString(name)) {
+      // the user simply wants to fetch the current data session by name
+      return getDataSession(name)
     }
-    setup = options.setup
-    validate = options.validate
-    onInvalidated = options.onInvalidated
-    shareAcrossSpecs = options.shareAcrossSpecs
-    recreate = options.recreate
-    preSetup = options.preSetup
-    dependsOn = options.dependsOn
-  }
 
-  if (typeof setup !== 'function') {
-    throw new Error('setup must be a function')
-  }
+    let shareAcrossSpecs = false
+    let init = Cypress._.noop
+    let preSetup
+    let recreate
+    let dependsOn
 
-  // always have "dependsOn" as an array of strings
-  if (typeof dependsOn === 'string') {
-    dependsOn = [dependsOn]
-  }
-  if (typeof dependsOn === 'undefined') {
-    dependsOn = []
-  }
-
-  if (typeof validate === 'undefined') {
-    // the user did not specify the validate function
-    // thus we will use any non-nil value
-    validate = () => true
-  } else if (validate === false) {
-    // if the user explicitly set the validate to false,
-    // recompute the data every time
-    validate = () => false
-  } else if (validate === true) {
-    // if the user explicitly set the validate to true,
-    // any non-nil value is valid
-    validate = () => true
-  } else {
-    // otherwise, we expect the user to pass in a function
-    if (typeof validate !== 'function') {
-      throw new Error('validate must be a function')
-    }
-  }
-
-  const pluginDisabled = Cypress.env('dataSessions') === false
-
-  const dataKey = formDataKey(name)
-
-  function getDependsOnTimestamps() {
-    return dependsOn.map((dep) => {
-      const ds = Cypress.getDataSessionDetails(dep)
-      if (!ds) {
-        throw new Error(
-          `Cannot find data session "${dep}" session "${name}" depends on`,
-        )
+    // check if we are using options / separate arguments
+    if (typeof name === 'object') {
+      const options = name
+      name = options.name
+      if ('init' in options) {
+        init = options.init
       }
-      return ds.timestamp
-    })
-  }
-
-  const setupSource = setup.toString()
-
-  const saveData = (data) => {
-    if (data === undefined) {
-      throw new Error('dataSession cannot yield undefined')
+      setup = options.setup
+      validate = options.validate
+      onInvalidated = options.onInvalidated
+      shareAcrossSpecs = options.shareAcrossSpecs
+      recreate = options.recreate
+      preSetup = options.preSetup
+      dependsOn = options.dependsOn
     }
 
-    return sha256(setupSource).then((setupHash) => {
-      if (!pluginDisabled) {
-        // only save the data if the plugin is enabled
-        // save the data for this session
-        const timestamp = +new Date()
-        const dependsOnTimestamps = getDependsOnTimestamps()
-
-        const sessionData = {
-          data,
-          timestamp,
-          dependsOnTimestamps,
-          setupHash,
-        }
-        setPluginConfigValue(dataKey, sessionData)
-        debug('set the data session %s to %o', dataKey, sessionData)
-
-        if (shareAcrossSpecs) {
-          debug('sharing the session %s across specs', dataKey)
-          cy.task('dataSession:save', { key: dataKey, value: sessionData })
-        }
-      }
-      // automatically create an alias
-      cy.wrap(data, { log: false }).as(name)
-    })
-  }
-
-  const setupAndSaveData = () => {
-    if (preSetup) {
-      cy.then(preSetup)
+    if (typeof setup !== 'function') {
+      throw new Error('setup must be a function')
     }
-    cy.then(setup).then(saveData)
-  }
 
-  if (pluginDisabled) {
-    cy.log('dataSessions disabled')
-    return setupAndSaveData()
-  }
+    // always have "dependsOn" as an array of strings
+    if (typeof dependsOn === 'string') {
+      dependsOn = [dependsOn]
+    }
+    if (typeof dependsOn === 'undefined') {
+      dependsOn = []
+    }
 
-  cy.log(`dataSession **${name}**`)
-
-  let entry = getPluginConfigValue(dataKey)
-  cy.wrap(entry ? entry.data : undefined, { log: false })
-    .then((value) => {
-      if (shareAcrossSpecs) {
-        return cy.task('dataSession:load', dataKey).then((loaded) => {
-          if (loaded) {
-            entry = loaded
-            return loaded.data
-          }
-          return undefined
-        })
+    if (typeof validate === 'undefined') {
+      // the user did not specify the validate function
+      // thus we will use any non-nil value
+      validate = () => true
+    } else if (validate === false) {
+      // if the user explicitly set the validate to false,
+      // recompute the data every time
+      validate = () => false
+    } else if (validate === true) {
+      // if the user explicitly set the validate to true,
+      // any non-nil value is valid
+      validate = () => true
+    } else {
+      // otherwise, we expect the user to pass in a function
+      if (typeof validate !== 'function') {
+        throw new Error('validate must be a function')
       }
-    })
-    .then((value) => {
-      // if the value is undefined or null,
-      // try generating it using the "init" callback
-      if (Cypress._.isNil(value)) {
-        if (!Cypress._.isFunction(init)) {
-          throw new Error('dataSession: init must be a function')
-        }
-        return cy.then(init).then((initValue) => {
-          if (Cypress._.isNil(initValue)) {
-            // we need to re-run the setup commands
-            cy.log(`first time for session **${name}**`)
-            return setupAndSaveData()
-          } else {
-            return cy
-              .then(() => validate(initValue))
-              .then((valid) => {
-                if (valid) {
-                  cy.log(`data **${name}** will use the init value`)
+    }
 
-                  if (Cypress._.isFunction(recreate)) {
-                    cy.log(`recreating the **${name}**`)
-                    return cy
-                      .then(() => recreate(initValue))
-                      .then(() => saveData(initValue, entry))
-                  } else {
-                    return saveData(initValue)
-                  }
-                } else {
-                  cy.log(`data **${name}** init did not pass validation`)
-                  return setupAndSaveData()
-                }
-              })
-          }
-        })
+    const pluginDisabled = Cypress.env('dataSessions') === false
+
+    const dataKey = formDataKey(name)
+
+    function getDependsOnTimestamps() {
+      return dependsOn.map((dep) => {
+        const ds = Cypress.getDataSessionDetails(dep)
+        if (!ds) {
+          throw new Error(
+            `Cannot find data session "${dep}" session "${name}" depends on`,
+          )
+        }
+        return ds.timestamp
+      })
+    }
+
+    const setupSource = setup.toString()
+
+    const saveData = (data) => {
+      if (data === undefined) {
+        throw new Error('dataSession cannot yield undefined')
       }
 
       return sha256(setupSource).then((setupHash) => {
-        if (entry && entry.setupHash && entry.setupHash !== setupHash) {
-          // the setup function has changed,
-          // we need to re-run the setup commands
-          cy.log(`setup function changed for session **${name}**`)
-          return setupAndSaveData()
-        }
+        if (!pluginDisabled) {
+          // only save the data if the plugin is enabled
+          // save the data for this session
+          const timestamp = +new Date()
+          const dependsOnTimestamps = getDependsOnTimestamps()
 
-        function returnValue() {
-          // yield the wrapped value to the next command in the test
-          return (
-            cy
-              .wrap(value, { log: false })
-              // and set as an alias
-              .as(name)
-          )
-        }
-
-        /**
-         * Looks up the timestamps from the data sessions
-         * this session depends on. If any of the timestamps
-         * are different, that means a "parent" data session
-         * was recomputed and we must recompute our data.
-         */
-        function parentsRecomputed() {
-          if (!entry) {
-            debug('there is no entry for name "%s"', name)
-            return false
+          const sessionData = {
+            data,
+            timestamp,
+            dependsOnTimestamps,
+            setupHash,
           }
-          if (!entry.dependsOnTimestamps) {
-            throw new Error(
-              `Missing depends on timestamps for data session "${name}"`,
+          setPluginConfigValue(dataKey, sessionData)
+          debug('set the data session %s to %o', dataKey, sessionData)
+
+          if (shareAcrossSpecs) {
+            debug('sharing the session %s across specs', dataKey)
+            cy.task('dataSession:save', { key: dataKey, value: sessionData })
+          }
+        }
+        // automatically create an alias
+        cy.wrap(data, { log: false }).as(name)
+      })
+    }
+
+    const setupAndSaveData = () => {
+      if (preSetup) {
+        cy.then(preSetup)
+      }
+      cy.then(setup).then(saveData)
+    }
+
+    if (pluginDisabled) {
+      cy.log('dataSessions disabled')
+      return setupAndSaveData()
+    }
+
+    cy.log(`dataSession **${name}**`)
+
+    let entry = getPluginConfigValue(dataKey)
+    cy.wrap(entry ? entry.data : undefined, { log: false })
+      .then((value) => {
+        if (shareAcrossSpecs) {
+          return cy.task('dataSession:load', dataKey).then((loaded) => {
+            if (loaded) {
+              entry = loaded
+              return loaded.data
+            }
+            return undefined
+          })
+        }
+      })
+      .then((value) => {
+        // if the value is undefined or null,
+        // try generating it using the "init" callback
+        if (Cypress._.isNil(value)) {
+          if (!Cypress._.isFunction(init)) {
+            throw new Error('dataSession: init must be a function')
+          }
+          return cy.then(init).then((initValue) => {
+            if (Cypress._.isNil(initValue)) {
+              // we need to re-run the setup commands
+              cy.log(`first time for session **${name}**`)
+              return setupAndSaveData()
+            } else {
+              return cy
+                .then(() => validate(initValue))
+                .then((valid) => {
+                  if (valid) {
+                    cy.log(`data **${name}** will use the init value`)
+
+                    if (Cypress._.isFunction(recreate)) {
+                      cy.log(`recreating the **${name}**`)
+                      return cy
+                        .then(() => recreate(initValue))
+                        .then(() => saveData(initValue, entry))
+                    } else {
+                      return saveData(initValue)
+                    }
+                  } else {
+                    cy.log(`data **${name}** init did not pass validation`)
+                    return setupAndSaveData()
+                  }
+                })
+            }
+          })
+        }
+
+        return sha256(setupSource).then((setupHash) => {
+          if (entry && entry.setupHash && entry.setupHash !== setupHash) {
+            // the setup function has changed,
+            // we need to re-run the setup commands
+            cy.log(`setup function changed for session **${name}**`)
+            return setupAndSaveData()
+          }
+
+          function returnValue() {
+            // yield the wrapped value to the next command in the test
+            return (
+              cy
+                .wrap(value, { log: false })
+                // and set as an alias
+                .as(name)
             )
           }
-          const currentTimestamps = getDependsOnTimestamps()
-          const same = Cypress._.isEqual(
-            entry.dependsOnTimestamps,
-            currentTimestamps,
-          )
-          return same
-        }
 
-        cy.then(() => validate(value)).then((valid) => {
-          if (valid) {
-            const parentSessionsAreTheSame = parentsRecomputed()
-            if (!parentSessionsAreTheSame) {
-              debug('parentSessionsAreTheSame', parentSessionsAreTheSame)
-              cy.log(
-                `recomputing **${name}** because a parent session has been recomputed`,
-              )
-            } else {
-              cy.log(`data **${name}** is still valid`)
-              if (Cypress._.isFunction(recreate)) {
-                cy.log(`recreating **${name}**`)
-                return cy
-                  .then(() => recreate(value))
-                  .then(() => {
-                    setPluginConfigValue(dataKey, entry)
-                    debug(
-                      'setting data session %s to %o and creating alias %s',
-                      dataKey,
-                      entry,
-                      name,
-                    )
-                    // automatically create an alias
-                    cy.wrap(value, { log: false }).as(name)
-                  })
-                  .then(returnValue)
-              }
-
-              if (!getPluginConfigValue(dataKey)) {
-                debug('Setting key %s to %o', dataKey, entry)
-                setPluginConfigValue(dataKey, entry)
-              }
-              return returnValue()
+          /**
+           * Looks up the timestamps from the data sessions
+           * this session depends on. If any of the timestamps
+           * are different, that means a "parent" data session
+           * was recomputed and we must recompute our data.
+           */
+          function parentsRecomputed() {
+            if (!entry) {
+              debug('there is no entry for name "%s"', name)
+              return false
             }
+            if (!entry.dependsOnTimestamps) {
+              throw new Error(
+                `Missing depends on timestamps for data session "${name}"`,
+              )
+            }
+            const currentTimestamps = getDependsOnTimestamps()
+            const same = Cypress._.isEqual(
+              entry.dependsOnTimestamps,
+              currentTimestamps,
+            )
+            return same
           }
 
-          cy.then(() => {
-            if (onInvalidated) {
-              return onInvalidated(value)
+          cy.then(() => validate(value)).then((valid) => {
+            if (valid) {
+              const parentSessionsAreTheSame = parentsRecomputed()
+              if (!parentSessionsAreTheSame) {
+                debug('parentSessionsAreTheSame', parentSessionsAreTheSame)
+                cy.log(
+                  `recomputing **${name}** because a parent session has been recomputed`,
+                )
+              } else {
+                cy.log(`data **${name}** is still valid`)
+                if (Cypress._.isFunction(recreate)) {
+                  cy.log(`recreating **${name}**`)
+                  return cy
+                    .then(() => recreate(value))
+                    .then(() => {
+                      setPluginConfigValue(dataKey, entry)
+                      debug(
+                        'setting data session %s to %o and creating alias %s',
+                        dataKey,
+                        entry,
+                        name,
+                      )
+                      // automatically create an alias
+                      cy.wrap(value, { log: false }).as(name)
+                    })
+                    .then(returnValue)
+                }
+
+                if (!getPluginConfigValue(dataKey)) {
+                  debug('Setting key %s to %o', dataKey, entry)
+                  setPluginConfigValue(dataKey, entry)
+                }
+                return returnValue()
+              }
             }
-          }).then(() => {
-            cy.log(`recompute data for **${name}**`)
-            // TODO: validate the value yielded by the setup
-            return setupAndSaveData()
+
+            cy.then(() => {
+              if (onInvalidated) {
+                return onInvalidated(value)
+              }
+            }).then(() => {
+              cy.log(`recompute data for **${name}**`)
+              // TODO: validate the value yielded by the setup
+              return setupAndSaveData()
+            })
           })
         })
       })
-    })
-})
+  },
+)
 
 //
 // Global methods


### PR DESCRIPTION
You can simply request the current data session, if any

```js
cy.dataSession('sessionName').then(value => {
  ...
})
```

If the data session is not found in memory, it tries to fetch it from the plugins space (maybe it is shared across specs). If still not found, it throws an error.